### PR TITLE
Fix package

### DIFF
--- a/simple-call-tree.el
+++ b/simple-call-tree.el
@@ -7,7 +7,7 @@
 ;; Copyleft (Ↄ) 2012, Joe Bloggs, all rites reversed.
 ;; Created: 2012-11-01 21:28:07
 ;; Version: 20151116.1603
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "24.3") (anaphora "1.0.0"))
 ;; Last-Updated: Mon Nov 16 16:03:18 2015
 ;;           By: Joe Bloggs
 ;; URL: http://www.emacswiki.org/emacs/download/simple-call-tree.el


### PR DESCRIPTION
Use cl-lib functions/macros instead of cl.el
- eval-when-compile must be removed because this packages uses not only macros
  but also functions
- Add package dependency header. cl-lib.el was bundled since Emacs 24.3.
  And this package also uses Emacs 24.3 feature like read-only-mode.
